### PR TITLE
feat: add useUnreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.4
+
+- Added `useUnreads` hook
+
 ## v0.1.3
 
 - Add `signature?: string` prop to `Session`

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,8 +1,8 @@
 import "./App.css";
 
-import { Session, Chatbox } from "../lib/main";
+import { Session, Chatbox, useUnreads } from "../lib/main";
 import Talk from "talkjs";
-import { ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
+import { ChangeEvent, useCallback, useMemo, useRef, useState, ReactElement } from "react";
 
 const convIds = ["talk-react-94872948u429843", "talk-react-194872948u429843"];
 const users = [
@@ -151,6 +151,7 @@ function App() {
           {...(blur ? { onBlur } : {})}
           style={{ width: 500, height: 600 }}
         />
+        <UnreadsDisplay />
       </Session>
       <button onClick={otherMe}>switch user (new session)</button>
       <br />
@@ -193,6 +194,28 @@ function App() {
       </fieldset>
     </>
   );
+}
+
+function UnreadsDisplay() {
+  const unreads = useUnreads();
+  let content: ReactElement | null = null;
+
+  if (unreads === undefined) {
+    content = <p>unreads is undefined (no session)</p>;
+  } else if (unreads.length === 0) {
+    content = <p>No unread messages</p>
+  } else {
+    content = <ul>
+      {unreads.map(u => {
+        return <li key={u.conversation.id}>{u.conversation.id} - {u.lastMessage.sender?.name || "system"}: {u.lastMessage.body}</li>
+      })}
+    </ul>
+  }
+
+  return <details>
+    <summary><strong>Unreads rendered with useUnreads</strong></summary>
+    {content}
+  </details>
 }
 
 export default App;

--- a/lib/main.tsx
+++ b/lib/main.tsx
@@ -3,4 +3,4 @@ export { Session } from "./Session";
 export { Chatbox } from "./ui/Chatbox";
 export { Inbox } from "./ui/Inbox";
 export { Popup } from "./ui/Popup";
-export { useSession } from "./SessionContext";
+export { useSession, useUnreads } from "./SessionContext";

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/talkjs/talkjs-react/issues"
   },
   "homepage": "https://talkjs.com",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This PR adds a `useUnreads` hook. While we do already have a prop for this on the Session component, the hook makes it easier to get the unreads lower down in the tree, without needing to pass them down from where you're rendering the Session.