### PR TITLE
(Fix) HtmlPanel crash bug

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -60,11 +60,6 @@ function App() {
     setConvId(convIds[nextConv]);
   }, [convId]);
 
-  const createUser = useCallback(() => {
-    console.log("createUser");
-    return new Talk.User(me);
-  }, [me]);
-
   const createConv = useCallback(
     (session: Talk.Session) => {
       console.log("createConv");
@@ -141,7 +136,7 @@ function App() {
     <>
       <Session
         appId={import.meta.env.VITE_APP_ID}
-        syncUser={createUser}
+        syncUser={() => new Talk.User(me)}
         onBrowserPermissionNeeded={onPerm}
         onUnreadsChange={onUnreads}
         sessionRef={sessionRef}

--- a/lib/Session.tsx
+++ b/lib/Session.tsx
@@ -39,14 +39,21 @@ export function Session(props: SessionProps) {
     Talk.ready.then(() => markReady(true));
   }, []);
 
-  useEffect(() => {
-    if (ready) {
-      const me =
-        typeof syncUser === "function"
-          ? syncUser()
-          : syncUser ?? new Talk.User(userId);
+  const me = ready
+    ? typeof syncUser === "function"
+      ? syncUser()
+      : syncUser ?? new Talk.User(userId)
+    : null;
 
-      const session = new Talk.Session({ appId, me, token, tokenFetcher, signature });
+  useEffect(() => {
+    if (me) {
+      const session = new Talk.Session({
+        appId,
+        me,
+        token,
+        tokenFetcher,
+        signature,
+      });
       setSession(session);
       if (sessionRef) {
         sessionRef.current = session;
@@ -65,7 +72,12 @@ export function Session(props: SessionProps) {
         }
       };
     }
-  }, [ready, signature, appId, userId, syncUser, sessionRef]);
+    // We intentionally add `me?.id` to the dependency array here instead of
+    // just `me`, because `me` is an object so a shallow comparison will always
+    // return `false`.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, signature, appId, userId, me?.id, sessionRef]);
 
   useMethod(
     session,

--- a/lib/Session.tsx
+++ b/lib/Session.tsx
@@ -77,7 +77,16 @@ export function Session(props: SessionProps) {
     // return `false`.
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ready, signature, appId, userId, me?.id, sessionRef]);
+  }, [
+    ready,
+    signature,
+    appId,
+    userId,
+    me?.id,
+    token,
+    tokenFetcher,
+    sessionRef,
+  ]);
 
   useMethod(
     session,


### PR DESCRIPTION
Fixes a bug that made the browser tab crash under certain conditions when `<Session>` re-renders.

`<Session>` has a `syncUser` prop that has the type `Talk.User | () => Talk.User`. `Session` uses an `useEffect` to destroy & reinitialize itself whenever the current user changes. However, passing the value of `syncUser` to the `useEffect` dependency array directly would result in the session being destroyed even if the user ID never changed, because `useEffect`'s dependency array does a shallow comparison that fails when `syncUser` is a non-memoized object/function.

The bug is fixed by passing the user ID to the dependency array instead of `syncUser`.