### PR TITLE
build: externalize react/jsx-runtime and react-dom/client

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
       formats: ["es", "umd", "cjs"],
     },
     rollupOptions: {
-      external: ["react", "talkjs"],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client', 'talkjs'],
       output: {
         globals: {
           react: "React",


### PR DESCRIPTION
Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production, by externalizing react/jsx-runtime and also for the future react-dom/client, should reduce the file size by about 10kb

See https://www.unpkg.com/@talkjs/react/dist/talkjs-react.js -> has references to ReactCurrentDispatcher and react/jsx-runtime

Also referred to / would have fixed #14 